### PR TITLE
Feature: RSVP Limit

### DIFF
--- a/packages/config/hackkit.config.ts
+++ b/packages/config/hackkit.config.ts
@@ -8,6 +8,7 @@ export default {
 	botName: "HackKit",
 	botParticipantRole: "RH25 Participant",
 	hackathonTimezone: "America/Chicago",
+	rsvpDefaultLimit: 500,
 	localUniversityName: "The University of Texas at San Antonio",
 	localUniversityShortIDName: "ABC123",
 	localUniversityShortIDMaxLength: 6,


### PR DESCRIPTION
- Added a default limit in hackkit.config.ts by the name of "rsvpDefaultLimit".
- Added logic to grab config:registration:maxRSVPs from KV which defaults to the default limit if it is not specified.
- Added database logic to check that the number of users who have RSVP'd does not exceed the limit whenever someone attempts to RSVP.