### PR TITLE
fixed xs screen size overriding all other sizes

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -13,12 +13,12 @@ module.exports = {
 		container: {
 			center: true,
 			padding: "2rem",
-			screens: {
-				"xs":'465px',
-				"2xl": "1400px",
-			},
 		},
 		extend: {
+			screens: {
+				xs: "465px",
+				"2xl": "1400px",
+			},
 			backgroundImage: {
 				"gradient-radial":
 					"radial-gradient(ellipse_at_center, var(--gradient-color-stops))",


### PR DESCRIPTION
Whenever I added the xs screen size for fixing text overflow with the hackkit dashboard I accidentally put the screen in the main theme instead of extending the existing screen sizes which overrode all the other screens.  This commit fixes this.